### PR TITLE
Place Z3 in PATH

### DIFF
--- a/dockerfiles/synth_formal
+++ b/dockerfiles/synth_formal
@@ -8,3 +8,5 @@ RUN apt-get update -qq \
     python3 \
  && apt-get autoclean && apt-get clean && apt-get -y autoremove \
  && rm -rf /var/lib/apt/lists/*
+
+ENV PATH /opt/z3/z3/bin:$PATH


### PR DESCRIPTION
The synth:formal image ships with the Z3 solver, but it is not in the PATH
```
docker run -it ghdl/synth:formal bash
root@7be5976e3a3a:/# z3
bash: z3: command not found
```

The location of the binary is `/opt/z3/z3/bin/z3`, but this is not in the PATH:
```
root@7be5976e3a3a:/# echo $PATH
/opt/ghdl/bin:/opt/yosys/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```

This PR adds the Z3 bin dir to the path.

Also not sure it is `opt/z3/z3` when ghdl is simply placed in `/opt/ghdl`.