### PR TITLE
Size optimize the VUnit images

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -167,6 +167,8 @@ extended() {
           --target="$version" \
           --build-arg TAG="$fulltag" \
           --build-arg PY_PACKAGES="$PY_PACKAGES"
+          # Sanity check that the VUnit package works
+          docker run --rm ghdl/vunit:$TAG python3 -c "import vunit; print(vunit.__version__)"
         done
       done
     ;;

--- a/vunit.dockerfile
+++ b/vunit.dockerfile
@@ -2,24 +2,29 @@
 
 ARG TAG="buster-mcode"
 
+#---
+
 FROM ghdl/ghdl:$TAG AS base
+
 ARG PY_PACKAGES
+
 RUN apt-get update -qq \
  && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
-    ca-certificates \
     curl \
     make \
     python3 \
     python3-pip \
  && apt-get autoclean && apt-get clean && apt-get -y autoremove \
- && update-ca-certificates \
  && rm -rf /var/lib/apt/lists/* \
- && pip3 install -U pip setuptools wheel $PY_PACKAGES
+ && pip3 install --upgrade setuptools wheel $PY_PACKAGES \
+ && rm -rf ~/.cache
 
 #---
 
 FROM base as stable
-RUN pip3 install vunit_hdl
+
+RUN pip3 install vunit_hdl \
+ && rm -rf ~/.cache
 
 #---
 
@@ -30,4 +35,4 @@ FROM base AS master
 RUN --mount=type=cache,from=get-master,src=/tmp/vunit,target=/tmp/vunit \
  cd /tmp/vunit \
  && pip3 install . \
- && rm -rf .cache
+ && rm -rf ~/.cache


### PR DESCRIPTION
Motivation: These docker images are used in CI in tsfpga and other projects. At the moment, in tsfpga, pulling the docker image represent a significant portion of the CI time. In order to save execution time, bandwidth and power, keeping docker images small should always be a priority.

In summary, -27 MB for the ``stable`` image, -75 MB for ``master`` image.

See the individual commits for details and some discussion around the individual changes.