### PR TITLE
Update prjtrellis Repo URL and pkg installation

### DIFF
--- a/cache_pnr.dockerfile
+++ b/cache_pnr.dockerfile
@@ -60,7 +60,7 @@ COPY --from=icestorm-build /opt/icestorm /
 #---
 
 FROM alpine as get-trellis
-RUN apk add --no-cache --update git && git clone --recurse-submodules https://github.com/SymbiFlow/prjtrellis /tmp/trellis \
+RUN apk add --no-cache --update git && git clone --recurse-submodules https://github.com/YosysHQ/prjtrellis /tmp/trellis \
  && cd /tmp/trellis \
  && git describe --tags > libtrellis/git_version
 

--- a/cache_pnr.dockerfile
+++ b/cache_pnr.dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update -qq \
  && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
     ca-certificates \
     curl \
+    make \
     python3 \
  && apt-get autoclean && apt-get clean && apt-get -y autoremove \
  && update-ca-certificates \
@@ -15,9 +16,7 @@ FROM base AS build
 
 RUN apt-get update -qq \
  && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
-    clang \
-    make
-
+    clang
 ENV CXX clang
 
 #---


### PR DESCRIPTION
- Use prjtrellis from [YosysHQ/prjtrellis](https://github.com/YosysHQ) instead [Symbiflow/prjtrellis](https://github.com/SymbiFlow/prjtrellis) which is stuck in June
- Install `make` already for the base layer
  - like in other dockerfile here
  - to use it directly within CI jobs