### PR TITLE
Add local CC symlink to GHDL/GCC installation in ghdl:run images

### DIFF
--- a/run_debian.dockerfile
+++ b/run_debian.dockerfile
@@ -33,6 +33,9 @@ RUN apt-get update -qq \
 
 FROM zlib AS gcc
 
+# make sure proper GCC version is used for linking (elaborate)
+RUN cd /usr/local/bin && ln -s gcc cc
+
 RUN apt-get update -qq \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     lcov \

--- a/vunit.dockerfile
+++ b/vunit.dockerfile
@@ -6,7 +6,6 @@ ARG TAG="bullseye-mcode"
 
 FROM ghdl/ghdl:$TAG AS base
 
-ARG TAG
 ARG PY_PACKAGES
 
 RUN apt-get update -qq \
@@ -19,9 +18,6 @@ RUN apt-get update -qq \
  && rm -rf /var/lib/apt/lists/* \
  && pip3 install --upgrade setuptools wheel $PY_PACKAGES \
  && rm -rf ~/.cache
-# Some combinations of system and GHDL versions of GCC break code coverage support
-# if GCC version bundled with GCC isn't used for linking, see issue #42
-RUN if echo "$TAG" | grep -q "gcc" ; then cd /usr/local/bin && ln -s gcc cc ; fi
 
 #---
 

--- a/vunit.dockerfile
+++ b/vunit.dockerfile
@@ -6,6 +6,7 @@ ARG TAG="bullseye-mcode"
 
 FROM ghdl/ghdl:$TAG AS base
 
+ARG TAG
 ARG PY_PACKAGES
 
 RUN apt-get update -qq \
@@ -18,6 +19,9 @@ RUN apt-get update -qq \
  && rm -rf /var/lib/apt/lists/* \
  && pip3 install --upgrade setuptools wheel $PY_PACKAGES \
  && rm -rf ~/.cache
+# Some combinations of system and GHDL versions of GCC break code coverage support
+# if GCC version bundled with GCC isn't used for linking, see issue #42
+RUN if echo "$TAG" | grep -q "gcc" ; then cd /usr/local/bin && ln -s gcc cc ; fi
 
 #---
 


### PR DESCRIPTION
There is some strange dependency between GCC version used for building code and GCC version used for linking if this code is built with code coverage enabled.
Looks like the safest bet is to use the same GCC version for both, but GCC version used by GHDL (installed in `/usr/local/`) had a missing `cc -> gcc` symlink.
This caused `/usr/local/bin/gcc` to be called by GHDL for compilation, but `/usr/bin/cc` (a symlink to `/usr/bin/gcc`) for linking, thus breaking code coverage.

Fixes #42 